### PR TITLE
fix: onRenderBody into gatsby-browser 😺👍

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Layout from './src/components/Layout';
+import { onRenderBody } from "./gatsby-ssr";
 
 export function wrapPageElement({ element, props }) {
-  return <Layout {...props}>{element}</Layout>;
+  return <Layout {...props}>{onRenderBody, element}</Layout>;
 }


### PR DESCRIPTION
```js
// gatsby-browser.js 😺👍
import React from 'react';
import Layout from './src/components/Layout';
import { onRenderBody } from "./gatsby-ssr";

export function wrapPageElement({ element, props }) {
  return <Layout {...props}>{onRenderBody, element}</Layout>;
}
```