### PR TITLE
fix: same in gatsby-ssr.js as gatsby-browser

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,39 +1,46 @@
 // gatsby-ssr.js
-import React from "react";
+import React from 'react';
+import Layout from './src/components/Layout';
 
-const OusetaScriptComponent = () => {
-  return (
-    <script
-      key="outseta-script"
-      id="outseta-script"
-      src="https://cdn.outseta.com/outseta.min.js"
-      data-options="o_options"
-    />
-  );
-};
+export function wrapPageElement({ element, props }) {
+  return <Layout {...props}>{element}</Layout>;
+}
 
-const OusetaConfigComponent = () => {
-  const config = {
-    domain: "queen.outseta.com",
-    monitorDom: true,
-  };
-  return (
-    <script
-      key="outseta-config"
-      id="outseta-config"
-      dangerouslySetInnerHTML={{
-        __html: `var o_options = ${JSON.stringify(config, null, 2)}`,
-      }}
-    />
-  );
-};
+// import React from "react";
+
+// const OusetaScriptComponent = () => {
+//   return (
+//     <script
+//       key="outseta-script"
+//       id="outseta-script"
+//       src="https://cdn.outseta.com/outseta.min.js"
+//       data-options="o_options"
+//     />
+//   );
+// };
+
+// const OusetaConfigComponent = () => {
+//   const config = {
+//     domain: "queen.outseta.com",
+//     monitorDom: true,
+//   };
+//   return (
+//     <script
+//       key="outseta-config"
+//       id="outseta-config"
+//       dangerouslySetInnerHTML={{
+//         __html: `var o_options = ${JSON.stringify(config, null, 2)}`,
+//       }}
+//     />
+//   );
+// };
 
 
 
-// B. Body setHead on body
+// // B. Body setHead on body
 
-const onRenderBody = ({ setHeadComponents }) => {
-  return setHeadComponents([OusetaConfigComponent(), OusetaScriptComponent()]);
-};
+// const onRenderBody = ({ setHeadComponents }) => {
+//   return setHeadComponents([OusetaConfigComponent(), OusetaScriptComponent()]);
+// };
 
-export { onRenderBody };
+// export { onRenderBody };


### PR DESCRIPTION
fix: same in gatsby-ssr.js as gatsby-browser

```js
// gatsby-ssr.js
import React from 'react';
import Layout from './src/components/Layout';

export function wrapPageElement({ element, props }) {
  return <Layout {...props}>{element}</Layout>;
}


```
